### PR TITLE
Add NOAA HMS ingestion path with normalization tests.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 # Get a free key at: https://firms.modaps.eosdis.nasa.gov/api/area/
 FIRMS_API_KEY=your_api_key_here
 
+# ── NOAA HMS Ingestion ──────────────────────────────────────────────────────
+# CSV endpoint that includes at least latitude/longitude and date/time fields.
+NOAA_HMS_CSV_URL=https://example.noaa.gov/hms/fire_points.csv
+# Used when NOAA payload has no confidence column.
+NOAA_HMS_CONFIDENCE_DEFAULT=medium
+
 # ── Database ────────────────────────────────────────────────────────────────
 # Path to the DuckDB database file (defaults to wildfire.db)
 # DB_PATH=wildfire.db

--- a/backend/src/ai_wildfire_tracker/ingest/firms.py
+++ b/backend/src/ai_wildfire_tracker/ingest/firms.py
@@ -1,50 +1,63 @@
 import os
-from dotenv import load_dotenv
-import pandas as pd
+
 import duckdb
+import pandas as pd
+from dotenv import load_dotenv
 
 load_dotenv()
-API_KEY = os.getenv("FIRMS_API_KEY")
-if not API_KEY:
-    raise RuntimeError("Missing FIRMS_API_KEY in .env")
+DB_PATH = os.getenv("DB_PATH", "wildfire.db")
 
-FIRMS_URL = f"https://firms.modaps.eosdis.nasa.gov/api/area/csv/{API_KEY}/VIIRS_SNPP_NRT/world/1"
-DB_PATH = "wildfire.db"
 
-def ingest_firms():
+def ensure_fires_table(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fires (
+            latitude DOUBLE,
+            longitude DOUBLE,
+            bright_ti4 DOUBLE,
+            bright_ti5 DOUBLE,
+            frp DOUBLE,
+            acq_date VARCHAR,
+            acq_time VARCHAR,
+            confidence VARCHAR
+        )
+        """
+    )
+
+
+def ingest_firms() -> None:
+    api_key = os.getenv("FIRMS_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing FIRMS_API_KEY in .env")
+
+    firms_url = (
+        f"https://firms.modaps.eosdis.nasa.gov/api/area/csv/{api_key}/VIIRS_SNPP_NRT/world/1"
+    )
     print("Fetching NASA FIRMS data...")
-    df = pd.read_csv(FIRMS_URL)
+    df = pd.read_csv(firms_url)
 
-    df = df[[
-        "latitude",
-        "longitude",
-        "bright_ti4",
-        "bright_ti5",
-        "frp",
-        "acq_date",
-        "acq_time",
-        "confidence"
-    ]]
+    df = df[
+        [
+            "latitude",
+            "longitude",
+            "bright_ti4",
+            "bright_ti5",
+            "frp",
+            "acq_date",
+            "acq_time",
+            "confidence",
+        ]
+    ]
 
     con = duckdb.connect(DB_PATH)
 
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS fires (
-        latitude DOUBLE,
-        longitude DOUBLE,
-        bright_ti4 DOUBLE,
-        bright_ti5 DOUBLE,
-        frp DOUBLE,
-        acq_date VARCHAR,
-        acq_time VARCHAR,
-        confidence VARCHAR
-        )
-    """)
+    ensure_fires_table(con)
 
     con.execute("INSERT INTO fires SELECT * FROM df")
     con.close()
 
-    print(f"Inserrted {len(df)} fire records into {DB_PATH}")
-    
+    print(f"Inserted {len(df)} fire records into {DB_PATH}")
+
+
 if __name__ == "__main__":
     ingest_firms()

--- a/backend/src/ai_wildfire_tracker/ingest/noaa_hms.py
+++ b/backend/src/ai_wildfire_tracker/ingest/noaa_hms.py
@@ -1,0 +1,90 @@
+import os
+from datetime import datetime, timezone
+
+import duckdb
+import pandas as pd
+from dotenv import load_dotenv
+
+from ai_wildfire_tracker.ingest.firms import ensure_fires_table
+
+load_dotenv()
+NOAA_HMS_CSV_URL = os.getenv("NOAA_HMS_CSV_URL")
+DB_PATH = os.getenv("DB_PATH", "wildfire.db")
+NOAA_HMS_CONFIDENCE_DEFAULT = os.getenv("NOAA_HMS_CONFIDENCE_DEFAULT", "medium")
+
+
+def _find_column(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    lowered = {c.lower(): c for c in df.columns}
+    for name in candidates:
+        if name.lower() in lowered:
+            return lowered[name.lower()]
+    return None
+
+
+def _normalize_noaa_hms(df: pd.DataFrame) -> pd.DataFrame:
+    lat_col = _find_column(df, ["latitude", "lat", "y"])
+    lon_col = _find_column(df, ["longitude", "lon", "long", "x"])
+    bright_col = _find_column(df, ["bright_ti4", "brightness", "temp", "temperature"])
+    frp_col = _find_column(df, ["frp", "power", "fire_radiative_power"])
+    conf_col = _find_column(df, ["confidence", "conf", "confidence_text"])
+    date_col = _find_column(df, ["acq_date", "date", "utc_date"])
+    time_col = _find_column(df, ["acq_time", "time", "utc_time"])
+    dt_col = _find_column(df, ["acq_datetime", "datetime", "timestamp", "date_time"])
+
+    if not lat_col or not lon_col:
+        raise ValueError("NOAA HMS payload must include latitude/longitude columns")
+
+    if not date_col and dt_col:
+        parsed = pd.to_datetime(df[dt_col], errors="coerce", utc=False)
+        df = df.copy()
+        df["__acq_date"] = parsed.dt.strftime("%Y-%m-%d")
+        df["__acq_time"] = parsed.dt.strftime("%H%M")
+        date_col = "__acq_date"
+        time_col = "__acq_time"
+
+    if not date_col:
+        raise ValueError("NOAA HMS payload must include acq_date/date or datetime")
+    if not time_col:
+        df = df.copy()
+        df["__acq_time"] = "0000"
+        time_col = "__acq_time"
+
+    normalized = pd.DataFrame(
+        {
+            "latitude": pd.to_numeric(df[lat_col], errors="coerce"),
+            "longitude": pd.to_numeric(df[lon_col], errors="coerce"),
+            "bright_ti4": pd.to_numeric(df[bright_col], errors="coerce") if bright_col else 0.0,
+            "bright_ti5": None,
+            "frp": pd.to_numeric(df[frp_col], errors="coerce") if frp_col else 0.0,
+            "acq_date": df[date_col].astype(str),
+            "acq_time": df[time_col].astype(str).str.replace(":", "", regex=False).str.zfill(4),
+            "confidence": df[conf_col].astype(str) if conf_col else NOAA_HMS_CONFIDENCE_DEFAULT,
+        }
+    )
+
+    normalized = normalized.dropna(subset=["latitude", "longitude"])
+    normalized["acq_date"] = normalized["acq_date"].replace(
+        {"NaT": datetime.now(timezone.utc).strftime("%Y-%m-%d")}
+    )
+    normalized["acq_time"] = normalized["acq_time"].replace({"nan": "0000", "None": "0000"})
+    return normalized
+
+
+def ingest_noaa_hms() -> None:
+    if not NOAA_HMS_CSV_URL:
+        raise RuntimeError("Missing NOAA_HMS_CSV_URL in environment")
+
+    print("Fetching NOAA HMS data...")
+    source_df = pd.read_csv(NOAA_HMS_CSV_URL)
+    normalized = _normalize_noaa_hms(source_df)
+
+    con = duckdb.connect(DB_PATH)
+    ensure_fires_table(con)
+    con.execute("INSERT INTO fires SELECT * FROM normalized")
+    con.close()
+
+    print(f"Inserted {len(normalized)} NOAA HMS records into {DB_PATH}")
+
+
+if __name__ == "__main__":
+    ingest_noaa_hms()

--- a/backend/tests/test_ingest_noaa_hms.py
+++ b/backend/tests/test_ingest_noaa_hms.py
@@ -1,0 +1,80 @@
+import duckdb
+import pandas as pd
+import pytest
+
+from ai_wildfire_tracker.ingest import noaa_hms
+
+
+def test_normalize_noaa_hms_with_datetime_column():
+    source = pd.DataFrame(
+        {
+            "LATITUDE": [34.1],
+            "LONGITUDE": [-118.2],
+            "BRIGHTNESS": [333.7],
+            "POWER": [25.4],
+            "datetime": ["2024-05-01T14:30:00"],
+            "CONFIDENCE": ["high"],
+        }
+    )
+
+    normalized = noaa_hms._normalize_noaa_hms(source)
+
+    assert list(normalized.columns) == [
+        "latitude",
+        "longitude",
+        "bright_ti4",
+        "bright_ti5",
+        "frp",
+        "acq_date",
+        "acq_time",
+        "confidence",
+    ]
+    assert normalized.iloc[0]["latitude"] == 34.1
+    assert normalized.iloc[0]["longitude"] == -118.2
+    assert normalized.iloc[0]["acq_date"] == "2024-05-01"
+    assert normalized.iloc[0]["acq_time"] == "1430"
+
+
+def test_ingest_noaa_hms_inserts_normalized_rows(monkeypatch, tmp_path):
+    db_path = tmp_path / "noaa.db"
+    sample = pd.DataFrame(
+        {
+            "lat": [36.0, None],
+            "lon": [-120.0, -121.0],
+            "temperature": [310.0, 299.0],
+            "frp": [9.5, 3.0],
+            "acq_date": ["2024-02-01", "2024-02-01"],
+            "acq_time": ["0915", "0930"],
+        }
+    )
+
+    monkeypatch.setattr(noaa_hms, "DB_PATH", str(db_path))
+    monkeypatch.setattr(noaa_hms, "NOAA_HMS_CSV_URL", "https://example.test/noaa.csv")
+    monkeypatch.setattr(noaa_hms.pd, "read_csv", lambda _: sample)
+
+    noaa_hms.ingest_noaa_hms()
+
+    con = duckdb.connect(str(db_path))
+    rows = con.execute(
+        """
+        SELECT latitude, longitude, bright_ti4, frp, acq_date, acq_time, confidence
+        FROM fires
+        """
+    ).fetchall()
+    con.close()
+
+    assert len(rows) == 1
+    assert rows[0][0] == 36.0
+    assert rows[0][1] == -120.0
+    assert rows[0][2] == 310.0
+    assert rows[0][3] == 9.5
+    assert rows[0][4] == "2024-02-01"
+    assert rows[0][5] == "0915"
+    assert rows[0][6] == noaa_hms.NOAA_HMS_CONFIDENCE_DEFAULT
+
+
+def test_ingest_noaa_hms_requires_url(monkeypatch):
+    monkeypatch.setattr(noaa_hms, "NOAA_HMS_CSV_URL", None)
+
+    with pytest.raises(RuntimeError, match="NOAA_HMS_CSV_URL"):
+        noaa_hms.ingest_noaa_hms()


### PR DESCRIPTION
Introduce a second wildfire ingestion source that maps NOAA HMS records into the existing fires schema so the current API can consume both feeds consistently.

