### PR TITLE
Add deterministic Playwright E2E coverage and CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,26 @@ jobs:
         run: npm install
       - name: Run Frontend Tests
         run: npm test -- --run
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with: { python-version: '3.12' }
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with: { node-version: '20' }
+      - name: Install Backend Dependencies
+        run: |
+          pip install -r ../backend/requirements.txt
+      - name: Install Frontend Dependencies
+        run: npm ci
+      - name: Install Playwright Browser
+        run: npx playwright install --with-deps chromium
+      - name: Run End-to-End Tests
+        run: npm run test:e2e:ci

--- a/README.md
+++ b/README.md
@@ -92,3 +92,25 @@ python main.py --help
 ## Notes
 - Add dependencies to `pyproject.toml` once stack decisions are made.
 - Prefer lightweight MVP choices (DuckDB + FastAPI) unless scaling is required.
+
+## End-to-end testing (Playwright)
+- E2E tests run with a deterministic seeded DuckDB fixture and do not call live FIRMS/NOAA feeds.
+- Test runner starts both backend (`uvicorn`) and frontend (`vite`) automatically.
+
+### Local run
+```bash
+# Backend deps are required for the E2E backend process
+python3 -m pip install -r backend/requirements.txt
+
+# Frontend deps + Playwright
+cd frontend
+npm install
+npx playwright install chromium
+
+# Run Chromium E2E suite
+npm run test:e2e
+```
+
+### CI behavior
+- GitHub Actions runs E2E on every push and pull request in a dedicated `test-e2e` job.
+- The suite is intentionally limited to five behavior-focused scenarios to reduce flake and runtime.

--- a/backend/tests/e2e/seed_db.py
+++ b/backend/tests/e2e/seed_db.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Create a deterministic DuckDB fixture for E2E tests."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import duckdb
+
+
+SEED_INSERT_SQL = """
+INSERT INTO fires VALUES
+    (34.05, -118.25, 360.0, 300.0, 55.0, '2025-06-01', '1210', 'high'),
+    (36.77, -119.41, 333.0, 295.0, 22.0, '2025-06-01', '1115', 'nominal'),
+    (38.58, -121.49, 310.0, 280.0, 10.0, '2025-06-01', '1030', 'low'),
+    (31.00, -100.00, 345.0, 302.0, 35.0, '2025-06-01', '0915', 'high'),
+    (28.50, -82.40, 305.0, 270.0, 12.0, '2025-06-01', '0830', 'low'),
+    (55.20, -120.50, 390.0, 320.0, 70.0, '2025-06-01', '1400', 'high')
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Seed DuckDB data for E2E tests")
+    parser.add_argument(
+        "--db-path",
+        default="backend/tests/e2e/e2e_wildfire.db",
+        help="Path to the DuckDB database file to create.",
+    )
+    return parser.parse_args()
+
+
+def seed_database(db_path: str) -> None:
+    target = Path(db_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.exists():
+        target.unlink()
+
+    con = duckdb.connect(str(target))
+    try:
+        con.execute(
+            """
+            CREATE TABLE fires (
+                latitude DOUBLE,
+                longitude DOUBLE,
+                bright_ti4 DOUBLE,
+                bright_ti5 DOUBLE,
+                frp DOUBLE,
+                acq_date VARCHAR,
+                acq_time VARCHAR,
+                confidence VARCHAR
+            )
+            """
+        )
+        con.execute(SEED_INSERT_SQL)
+    finally:
+        con.close()
+
+
+def main() -> None:
+    args = parse_args()
+    seed_database(args.db_path)
+    print(f"Seeded E2E DuckDB at {os.path.abspath(args.db_path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/e2e/fires.spec.ts
+++ b/frontend/e2e/fires.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("AI Wildfire Tracker E2E", () => {
+  test("loads with seeded California results and no API error", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("events-count")).toHaveText("3 events");
+    await expect(page.locator(".error-banner")).toHaveCount(0);
+  });
+
+  test("starts with California-only filter enabled", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("ca-toggle")).toBeChecked();
+    await expect(page.getByTestId("events-count")).toHaveText("3 events");
+    await expect(page.getByText("Lat/Lon: 31.00, -100.00")).toHaveCount(0);
+  });
+
+  test("expands result set when California-only is turned off", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("events-count")).toHaveText("3 events");
+    await page.getByTestId("ca-toggle").uncheck();
+    await expect(page.getByTestId("ca-toggle")).not.toBeChecked();
+    await expect(page.getByTestId("events-count")).toHaveText("5 events");
+    await expect(page.getByText("Lat/Lon: 31.00, -100.00")).toBeVisible();
+  });
+
+  test("applies confidence filter and FRP ascending sort", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await page.getByTestId("ca-toggle").uncheck();
+    await expect(page.getByTestId("ca-toggle")).not.toBeChecked();
+    await expect(page.getByTestId("events-count")).toHaveText("5 events");
+
+    await page.getByTestId("confidence-filter").selectOption("high");
+    await expect(page.getByTestId("events-count")).toHaveText("2 events");
+
+    await page.getByTestId("sort-key").selectOption("frp");
+    await page.getByTestId("sort-dir").click();
+
+    const firstRow = page.getByTestId("event-row").first();
+    await expect(firstRow).toContainText("FRP: 35");
+  });
+
+  test("shows empty-state message when brightness excludes all events", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await page.getByTestId("brightness-filter").fill("999");
+
+    await expect(page.getByText("No events match filters.")).toBeVisible();
+    await expect(page.getByTestId("events-count")).toHaveText("0 events");
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
+        "@playwright/test": "^1.53.0",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -1163,6 +1164,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -5215,6 +5232,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,10 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ci": "playwright test --reporter=line"
   },
   "dependencies": {
     "leaflet": "^1.9.4",
@@ -20,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@playwright/test": "^1.53.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const isCI = !!process.env.GITHUB_ACTIONS;
+const seededDbPath = "../backend/tests/e2e/e2e_wildfire.db";
+const backendPort = 38765;
+const frontendPort = 38766;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? [["github"], ["html", { open: "never" }]] : [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${frontendPort}`,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: `python3 ../backend/tests/e2e/seed_db.py --db-path ${seededDbPath} && TEST_DB_PATH=${seededDbPath} PYTHONPATH=../backend/src python3 -m uvicorn ai_wildfire_tracker.api.server:app --host 127.0.0.1 --port ${backendPort}`,
+      url: `http://127.0.0.1:${backendPort}/health`,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+      cwd: ".",
+    },
+    {
+      command: `VITE_API_BASE_URL=http://127.0.0.1:${backendPort} npm run dev -- --host 127.0.0.1 --port ${frontendPort}`,
+      url: `http://127.0.0.1:${frontendPort}`,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+      cwd: ".",
+    },
+  ],
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -193,6 +193,8 @@ export default function App() {
   }, [filteredFires]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     async function load() {
       try {
         setLoading(true);
@@ -201,17 +203,24 @@ export default function App() {
         const apiBase = `${API_BASE || "/api"}`.replace(/\/$/, "");
         const url = new URL(`${apiBase}/fires`, window.location.origin);
         if (californiaOnly) url.searchParams.set("region", "ca");
-        const res = await fetch(url.toString());
+        const res = await fetch(url.toString(), { signal: controller.signal });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
+        if (controller.signal.aborted) return;
         setFires(data.slice(0, 1000));
       } catch (e) {
+        if (controller.signal.aborted) return;
         setErr(String(e));
       } finally {
+        if (controller.signal.aborted) return;
         setLoading(false);
       }
     }
     load();
+
+    return () => {
+      controller.abort();
+    };
   }, [californiaOnly]);
 
   return (
@@ -233,10 +242,11 @@ export default function App() {
       <div className="main-layout">
         <section className="controls-panel">
           <h3>Filters</h3>
-          <label>
+          <div>
             <span>Region</span>
-            <label className="checkbox-row" data-testid="ca-toggle-label">
+            <label htmlFor="ca-toggle" className="checkbox-row" data-testid="ca-toggle-label">
               <input
+                id="ca-toggle"
                 data-testid="ca-toggle"
                 type="checkbox"
                 checked={californiaOnly}
@@ -245,7 +255,7 @@ export default function App() {
               California only
             </label>
             <small>Data shown is US-only; toggle narrows to California.</small>
-          </label>
+          </div>
           <label>
             Confidence
             <select

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -19,5 +19,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./src/setupTests.js",
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
 });


### PR DESCRIPTION
This introduces a seeded DuckDB E2E flow with Chromium Playwright tests, integrates it into CI on every PR, and hardens the frontend region-fetch path to avoid stale request races during toggle-driven reloads.

