### PR TITLE
Fire history api+tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ NOAA_HMS_CONFIDENCE_DEFAULT=medium
 # ── Database ────────────────────────────────────────────────────────────────
 # Path to the DuckDB database file (defaults to wildfire.db)
 # DB_PATH=wildfire.db
+
+# ── NWS API ───────────────────────────────────────────────────────────────
+NWS_USER_AGENT=ai-wildfire-tracker/1.0 (your-email@email.com)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pandas==2.2.0
 duckdb>=0.10.0
 apscheduler>=3.10.4
 pytest-cov>=4.1.0
+shapely==2.1.2

--- a/backend/src/ai_wildfire_tracker/ingest/ndvi.py
+++ b/backend/src/ai_wildfire_tracker/ingest/ndvi.py
@@ -60,6 +60,7 @@ SESSION.headers.update({"Accept": "application/json"})
 # Schema helpers
 # ---------------------------------------------------------------------------
 
+
 def ensure_environmental_table(con: duckdb.DuckDBPyConnection) -> None:
     con.execute(
         """
@@ -79,6 +80,7 @@ def ensure_environmental_table(con: duckdb.DuckDBPyConnection) -> None:
 # ---------------------------------------------------------------------------
 # Open-Meteo API helper
 # ---------------------------------------------------------------------------
+
 
 def fetch_environmental_conditions(lat: float, lon: float) -> dict | None:
     """
@@ -135,6 +137,7 @@ def fetch_environmental_conditions(lat: float, lon: float) -> dict | None:
 # Dedup: skip points already fetched today
 # ---------------------------------------------------------------------------
 
+
 def _already_fetched_today(
     con: duckdb.DuckDBPyConnection, lat: float, lon: float, today: str
 ) -> bool:
@@ -155,6 +158,7 @@ def _already_fetched_today(
 # Public ingest function
 # ---------------------------------------------------------------------------
 
+
 def ingest_environmental(limit: int = OPEN_METEO_MAX_POINTS) -> int:
     """
     For each unique fire detection point in the fires table (up to `limit`),
@@ -164,9 +168,7 @@ def ingest_environmental(limit: int = OPEN_METEO_MAX_POINTS) -> int:
     Returns the number of new rows inserted.
     """
     if not os.path.exists(DB_PATH):
-        raise FileNotFoundError(
-            f"Database not found: {DB_PATH}. Run FIRMS ingest first."
-        )
+        raise FileNotFoundError(f"Database not found: {DB_PATH}. Run FIRMS ingest first.")
 
     con = duckdb.connect(DB_PATH)
     ensure_environmental_table(con)
@@ -204,9 +206,7 @@ def ingest_environmental(limit: int = OPEN_METEO_MAX_POINTS) -> int:
         con.close()
         return 0
 
-    logger.info(
-        "Fetching Open-Meteo environmental conditions for %d points", len(points_df)
-    )
+    logger.info("Fetching Open-Meteo environmental conditions for %d points", len(points_df))
     rows = []
 
     for _, row in points_df.iterrows():

--- a/backend/src/ai_wildfire_tracker/ingest/ndvi.py
+++ b/backend/src/ai_wildfire_tracker/ingest/ndvi.py
@@ -1,0 +1,262 @@
+"""
+ndvi.py — Environmental conditions ingestor for AI Wildfire Tracker
+
+Fetches surface-level environmental conditions for each fire detection point
+using the Open-Meteo API (free, no API key required).
+
+Variables fetched (strong wildfire risk indicators used in NFDRS):
+    soil_moisture_0_to_1cm       — hourly volumetric soil water (m³/m³)
+                                   Low values = dry fuel = higher ignition risk
+    vapor_pressure_deficit_max   — daily VPD in kPa
+                                   High VPD = vegetation stress = higher fire risk
+    et0_fao_evapotranspiration   — daily reference ET in mm
+                                   High ET = dry surface conditions
+
+
+Open-Meteo docs: https://open-meteo.com/en/docs
+
+Table created: environmental_conditions
+Schema:
+    latitude      DOUBLE
+    longitude     DOUBLE
+    obs_date      VARCHAR  — YYYY-MM-DD
+    soil_moisture DOUBLE   — mean of 24 hourly values (m³/m³)
+    vpd_kpa       DOUBLE   — vapor pressure deficit in kPa
+    et0_mm        DOUBLE   — evapotranspiration in mm
+    fetched_at    VARCHAR  — ISO timestamp of ingest run
+"""
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+import duckdb
+import pandas as pd
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_PATH = os.getenv("DB_PATH", "wildfire.db")
+OPEN_METEO_BASE = "https://api.open-meteo.com/v1/forecast"
+OPEN_METEO_SLEEP = float(os.getenv("OPEN_METEO_SLEEP", "0.5"))
+OPEN_METEO_MAX_POINTS = int(os.getenv("OPEN_METEO_MAX_POINTS", "100"))
+
+US_BOUNDS = {
+    "min_lat": 24.0,
+    "max_lat": 49.5,
+    "min_lon": -125.0,
+    "max_lon": -66.5,
+}
+
+logger = logging.getLogger(__name__)
+
+SESSION = requests.Session()
+SESSION.headers.update({"Accept": "application/json"})
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+def ensure_environmental_table(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS environmental_conditions (
+            latitude      DOUBLE,
+            longitude     DOUBLE,
+            obs_date      VARCHAR,
+            soil_moisture DOUBLE,
+            vpd_kpa       DOUBLE,
+            et0_mm        DOUBLE,
+            fetched_at    VARCHAR
+        )
+        """
+    )
+
+
+# ---------------------------------------------------------------------------
+# Open-Meteo API helper
+# ---------------------------------------------------------------------------
+
+def fetch_environmental_conditions(lat: float, lon: float) -> dict | None:
+    """
+    Fetch today's environmental conditions for a lat/lon point from Open-Meteo.
+
+    Uses:
+        hourly=soil_moisture_0_to_1cm       (mean of 24 hourly values)
+        daily=vapor_pressure_deficit_max
+        daily=et0_fao_evapotranspiration
+
+    Returns a flat dict with soil_moisture, vpd_kpa, et0_mm or None on failure.
+    """
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "hourly": "soil_moisture_0_to_1cm",
+        "daily": [
+            "vapor_pressure_deficit_max",
+            "et0_fao_evapotranspiration",
+        ],
+        "timezone": "America/Los_Angeles",
+        "forecast_days": 1,
+    }
+
+    try:
+        resp = SESSION.get(OPEN_METEO_BASE, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("Open-Meteo request failed for %.4f,%.4f: %s", lat, lon, exc)
+        return None
+
+    try:
+        # Soil moisture: mean of all 24 hourly values for today
+        hourly_values = data["hourly"]["soil_moisture_0_to_1cm"]
+        valid = [v for v in hourly_values if v is not None]
+        soil_moisture = round(sum(valid) / len(valid), 4) if valid else 0.0
+
+        daily = data["daily"]
+        vpd_kpa = float(daily["vapor_pressure_deficit_max"][0] or 0.0)
+        et0_mm = float(daily["et0_fao_evapotranspiration"][0] or 0.0)
+
+        return {
+            "soil_moisture": soil_moisture,
+            "vpd_kpa": round(vpd_kpa, 3),
+            "et0_mm": round(et0_mm, 3),
+        }
+    except (KeyError, IndexError, TypeError, ZeroDivisionError) as exc:
+        logger.warning("Unexpected Open-Meteo response for %.4f,%.4f: %s", lat, lon, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dedup: skip points already fetched today
+# ---------------------------------------------------------------------------
+
+def _already_fetched_today(
+    con: duckdb.DuckDBPyConnection, lat: float, lon: float, today: str
+) -> bool:
+    try:
+        result = con.execute(
+            """
+            SELECT COUNT(*) FROM environmental_conditions
+            WHERE latitude = ? AND longitude = ? AND obs_date = ?
+            """,
+            [lat, lon, today],
+        ).fetchone()
+        return (result[0] or 0) > 0
+    except duckdb.CatalogException:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public ingest function
+# ---------------------------------------------------------------------------
+
+def ingest_environmental(limit: int = OPEN_METEO_MAX_POINTS) -> int:
+    """
+    For each unique fire detection point in the fires table (up to `limit`),
+    fetch environmental conditions from Open-Meteo and store in
+    environmental_conditions table.
+
+    Returns the number of new rows inserted.
+    """
+    if not os.path.exists(DB_PATH):
+        raise FileNotFoundError(
+            f"Database not found: {DB_PATH}. Run FIRMS ingest first."
+        )
+
+    con = duckdb.connect(DB_PATH)
+    ensure_environmental_table(con)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    fetched_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        points_df = con.execute(
+            """
+            SELECT DISTINCT
+                ROUND(latitude, 2)  AS lat,
+                ROUND(longitude, 2) AS lon
+            FROM fires
+            WHERE latitude  BETWEEN ? AND ?
+              AND longitude BETWEEN ? AND ?
+            ORDER BY lat DESC
+            LIMIT ?
+            """,
+            [
+                US_BOUNDS["min_lat"],
+                US_BOUNDS["max_lat"],
+                US_BOUNDS["min_lon"],
+                US_BOUNDS["max_lon"],
+                int(limit),
+            ],
+        ).df()
+    except duckdb.CatalogException:
+        logger.warning("fires table does not exist yet — run FIRMS ingest first")
+        con.close()
+        return 0
+
+    if points_df.empty:
+        logger.info("No fire points found in DB — nothing to enrich")
+        con.close()
+        return 0
+
+    logger.info(
+        "Fetching Open-Meteo environmental conditions for %d points", len(points_df)
+    )
+    rows = []
+
+    for _, row in points_df.iterrows():
+        lat, lon = float(row["lat"]), float(row["lon"])
+
+        if _already_fetched_today(con, lat, lon, today):
+            logger.debug("Skipping already-fetched point %.2f,%.2f", lat, lon)
+            continue
+
+        conditions = fetch_environmental_conditions(lat, lon)
+        if not conditions:
+            time.sleep(OPEN_METEO_SLEEP)
+            continue
+
+        rows.append(
+            {
+                "latitude": lat,
+                "longitude": lon,
+                "obs_date": today,
+                "soil_moisture": conditions["soil_moisture"],
+                "vpd_kpa": conditions["vpd_kpa"],
+                "et0_mm": conditions["et0_mm"],
+                "fetched_at": fetched_at,
+            }
+        )
+        logger.info(
+            "Fetched %.2f,%.2f → soil=%.4f  vpd=%.2f kPa  et0=%.2f mm",
+            lat,
+            lon,
+            conditions["soil_moisture"],
+            conditions["vpd_kpa"],
+            conditions["et0_mm"],
+        )
+        time.sleep(OPEN_METEO_SLEEP)
+
+    if rows:
+        env_df = pd.DataFrame(rows)  # noqa: F841 — DuckDB references by name
+        con.execute("INSERT INTO environmental_conditions SELECT * FROM env_df")
+        logger.info("Inserted %d environmental rows into %s", len(rows), DB_PATH)
+    else:
+        logger.info("No new environmental rows to insert")
+
+    con.close()
+    return len(rows)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    inserted = ingest_environmental()
+    print(f"Done — inserted {inserted} environmental observations")

--- a/backend/src/ai_wildfire_tracker/ingest/nifc.py
+++ b/backend/src/ai_wildfire_tracker/ingest/nifc.py
@@ -1,0 +1,320 @@
+"""
+nifc.py — NIFC fire perimeter ingestor for AI Wildfire Tracker
+backend/src/ai_wildfire_tracker/ingest/nifc.py
+
+Downloads WFIGS current interagency fire perimeters from the NIFC ArcGIS
+REST API and performs a spatial join against FIRMS fire detection points
+to assign binary training labels for the Random Forest model.
+
+Label definition:
+    1 = a NIFC fire perimeter overlaps this detection point (fire confirmed)
+    0 = no perimeter overlap (no confirmed fire at this point)
+
+NIFC ArcGIS REST endpoint (no API key required, public domain):
+    https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/
+    WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query
+
+Verified working Postman call (2026-04-19):
+    GET .../query?where=1%3D1&outFields=poly_IncidentName,poly_GISAcres,
+    poly_CreateDate&returnGeometry=true&outSR=4326&f=geojson&resultRecordCount=5
+
+Tables created:
+    fire_perimeters — raw perimeter polygons (GeoJSON geometry as string)
+    fire_labels     — one row per FIRMS detection with label 0 or 1
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import duckdb
+import pandas as pd
+import requests
+from dotenv import load_dotenv
+from shapely.geometry import Point, shape
+
+load_dotenv()
+
+DB_PATH = os.getenv("DB_PATH", "wildfire.db")
+
+NIFC_URL = (
+    "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services"
+    "/WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query"
+)
+
+US_BOUNDS = {
+    "min_lat": 24.0,
+    "max_lat": 49.5,
+    "min_lon": -125.0,
+    "max_lon": -66.5,
+}
+
+NIFC_MAX_FEATURES = int(os.getenv("NIFC_MAX_FEATURES", "1000"))
+
+logger = logging.getLogger(__name__)
+
+SESSION = requests.Session()
+SESSION.headers.update({"Accept": "application/json"})
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_perimeter_table(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fire_perimeters (
+            incident_name VARCHAR,
+            gis_acres     DOUBLE,
+            create_date   VARCHAR,
+            geometry_json VARCHAR,
+            fetched_at    VARCHAR
+        )
+        """
+    )
+
+
+def ensure_labels_table(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fire_labels (
+            latitude   DOUBLE,
+            longitude  DOUBLE,
+            acq_date   VARCHAR,
+            label      INTEGER,
+            labeled_at VARCHAR
+        )
+        """
+    )
+
+
+# ---------------------------------------------------------------------------
+# NIFC API helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_nifc_perimeters(max_features: int = NIFC_MAX_FEATURES) -> list[dict]:
+    """
+    Fetch current fire perimeter GeoJSON features from NIFC ArcGIS REST API.
+    Returns a list of GeoJSON feature dicts, empty list on failure.
+    """
+    params = {
+        "where": "1=1",
+        "outFields": "poly_IncidentName,poly_GISAcres,poly_CreateDate",
+        "returnGeometry": "true",
+        "outSR": "4326",
+        "f": "geojson",
+        "resultRecordCount": max_features,
+    }
+
+    try:
+        resp = SESSION.get(NIFC_URL, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.error("NIFC request failed: %s", exc)
+        return []
+
+    if "error" in data:
+        logger.error("NIFC API error: %s", data["error"])
+        return []
+
+    features = data.get("features", [])
+    logger.info("Fetched %d NIFC perimeter features", len(features))
+    return features
+
+
+def store_perimeters(
+    con: duckdb.DuckDBPyConnection, features: list[dict], fetched_at: str
+) -> int:
+    """Store raw perimeter features in fire_perimeters table. Returns count inserted."""
+    if not features:
+        return 0
+
+    rows = []
+    for f in features:
+        props = f.get("properties", {})
+        rows.append(
+            {
+                "incident_name": str(props.get("poly_IncidentName") or ""),
+                "gis_acres": float(props.get("poly_GISAcres") or 0.0),
+                "create_date": str(props.get("poly_CreateDate") or ""),
+                "geometry_json": json.dumps(f.get("geometry", {})),
+                "fetched_at": fetched_at,
+            }
+        )
+
+    perimeters_df = pd.DataFrame(rows)  # noqa: F841 — DuckDB references by name
+    con.execute("INSERT INTO fire_perimeters SELECT * FROM perimeters_df")
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Spatial join helpers
+# ---------------------------------------------------------------------------
+
+
+def build_shapely_polygons(features: list[dict]) -> list:
+    """Convert GeoJSON feature list to valid Shapely geometry objects."""
+    polygons = []
+    for f in features:
+        try:
+            geom = shape(f["geometry"])
+            if geom.is_valid:
+                polygons.append(geom)
+        except Exception as exc:
+            logger.debug("Skipping invalid geometry: %s", exc)
+    return polygons
+
+
+def point_in_any_perimeter(lat: float, lon: float, polygons: list) -> bool:
+    """Return True if (lat, lon) falls inside any perimeter polygon."""
+    pt = Point(lon, lat)  # Shapely uses (lon, lat) order
+    return any(poly.contains(pt) for poly in polygons)
+
+
+def label_fire_detections(
+    con: duckdb.DuckDBPyConnection, polygons: list, labeled_at: str
+) -> int:
+    """
+    For each FIRMS detection in the fires table, assign label 1 if the point
+    falls inside a NIFC perimeter polygon, else 0.
+    Skips points already labeled. Returns count of new labeled rows inserted.
+    """
+    try:
+        detections = con.execute(
+            """
+            SELECT DISTINCT
+                ROUND(latitude, 2)  AS lat,
+                ROUND(longitude, 2) AS lon,
+                acq_date
+            FROM fires
+            WHERE latitude  BETWEEN ? AND ?
+              AND longitude BETWEEN ? AND ?
+            """,
+            [
+                US_BOUNDS["min_lat"],
+                US_BOUNDS["max_lat"],
+                US_BOUNDS["min_lon"],
+                US_BOUNDS["max_lon"],
+            ],
+        ).df()
+    except duckdb.CatalogException:
+        logger.warning("fires table not found — run FIRMS ingest first")
+        return 0
+
+    if detections.empty:
+        logger.info("No fire detections found to label")
+        return 0
+
+    # Load already-labeled keys to avoid duplicates
+    try:
+        existing = con.execute(
+            "SELECT latitude, longitude, acq_date FROM fire_labels"
+        ).df()
+        existing_keys = set(
+            zip(existing["latitude"], existing["longitude"], existing["acq_date"])
+        )
+    except duckdb.CatalogException:
+        existing_keys = set()
+
+    rows = []
+    for _, row in detections.iterrows():
+        lat = float(row["lat"])
+        lon = float(row["lon"])
+        acq_date = str(row["acq_date"])
+
+        if (lat, lon, acq_date) in existing_keys:
+            continue
+
+        label = 1 if point_in_any_perimeter(lat, lon, polygons) else 0
+        rows.append(
+            {
+                "latitude": lat,
+                "longitude": lon,
+                "acq_date": acq_date,
+                "label": label,
+                "labeled_at": labeled_at,
+            }
+        )
+
+    if rows:
+        labels_df = pd.DataFrame(rows)  # noqa: F841 — DuckDB references by name
+        con.execute("INSERT INTO fire_labels SELECT * FROM labels_df")
+        pos = sum(r["label"] for r in rows)
+        logger.info(
+            "Labeled %d detections: %d positive (fire), %d negative",
+            len(rows),
+            pos,
+            len(rows) - pos,
+        )
+
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Public ingest function
+# ---------------------------------------------------------------------------
+
+
+def ingest_nifc() -> dict:
+    """
+    Fetch NIFC current fire perimeters and label FIRMS detection points.
+
+    Returns a summary dict:
+        perimeters_inserted: int
+        detections_labeled:  int
+        positive_labels:     int
+    """
+    if not os.path.exists(DB_PATH):
+        raise FileNotFoundError(
+            f"Database not found: {DB_PATH}. Run FIRMS ingest first."
+        )
+
+    con = duckdb.connect(DB_PATH)
+    ensure_perimeter_table(con)
+    ensure_labels_table(con)
+
+    fetched_at = datetime.now(timezone.utc).isoformat()
+
+    features = fetch_nifc_perimeters()
+    if not features:
+        logger.warning("No NIFC perimeters fetched — labels will all be 0")
+        con.close()
+        return {"perimeters_inserted": 0, "detections_labeled": 0, "positive_labels": 0}
+
+    perimeters_inserted = store_perimeters(con, features, fetched_at)
+    polygons = build_shapely_polygons(features)
+    logger.info("Built %d valid Shapely polygons for spatial join", len(polygons))
+
+    detections_labeled = label_fire_detections(con, polygons, fetched_at)
+
+    try:
+        result = con.execute(
+            "SELECT COUNT(*) FROM fire_labels WHERE label = 1"
+        ).fetchone()
+        positive_labels = result[0] or 0
+    except duckdb.CatalogException:
+        positive_labels = 0
+
+    con.close()
+
+    summary = {
+        "perimeters_inserted": perimeters_inserted,
+        "detections_labeled": detections_labeled,
+        "positive_labels": positive_labels,
+    }
+    logger.info("NIFC ingest complete: %s", summary)
+    return summary
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    summary = ingest_nifc()
+    print(f"Done — {summary}")

--- a/backend/src/ai_wildfire_tracker/ingest/nifc.py
+++ b/backend/src/ai_wildfire_tracker/ingest/nifc.py
@@ -1,6 +1,5 @@
 """
 nifc.py — NIFC fire perimeter ingestor for AI Wildfire Tracker
-backend/src/ai_wildfire_tracker/ingest/nifc.py
 
 Downloads WFIGS current interagency fire perimeters from the NIFC ArcGIS
 REST API and performs a spatial join against FIRMS fire detection points
@@ -127,9 +126,7 @@ def fetch_nifc_perimeters(max_features: int = NIFC_MAX_FEATURES) -> list[dict]:
     return features
 
 
-def store_perimeters(
-    con: duckdb.DuckDBPyConnection, features: list[dict], fetched_at: str
-) -> int:
+def store_perimeters(con: duckdb.DuckDBPyConnection, features: list[dict], fetched_at: str) -> int:
     """Store raw perimeter features in fire_perimeters table. Returns count inserted."""
     if not features:
         return 0
@@ -176,9 +173,7 @@ def point_in_any_perimeter(lat: float, lon: float, polygons: list) -> bool:
     return any(poly.contains(pt) for poly in polygons)
 
 
-def label_fire_detections(
-    con: duckdb.DuckDBPyConnection, polygons: list, labeled_at: str
-) -> int:
+def label_fire_detections(con: duckdb.DuckDBPyConnection, polygons: list, labeled_at: str) -> int:
     """
     For each FIRMS detection in the fires table, assign label 1 if the point
     falls inside a NIFC perimeter polygon, else 0.
@@ -212,12 +207,8 @@ def label_fire_detections(
 
     # Load already-labeled keys to avoid duplicates
     try:
-        existing = con.execute(
-            "SELECT latitude, longitude, acq_date FROM fire_labels"
-        ).df()
-        existing_keys = set(
-            zip(existing["latitude"], existing["longitude"], existing["acq_date"])
-        )
+        existing = con.execute("SELECT latitude, longitude, acq_date FROM fire_labels").df()
+        existing_keys = set(zip(existing["latitude"], existing["longitude"], existing["acq_date"]))
     except duckdb.CatalogException:
         existing_keys = set()
 
@@ -270,9 +261,7 @@ def ingest_nifc() -> dict:
         positive_labels:     int
     """
     if not os.path.exists(DB_PATH):
-        raise FileNotFoundError(
-            f"Database not found: {DB_PATH}. Run FIRMS ingest first."
-        )
+        raise FileNotFoundError(f"Database not found: {DB_PATH}. Run FIRMS ingest first.")
 
     con = duckdb.connect(DB_PATH)
     ensure_perimeter_table(con)
@@ -293,9 +282,7 @@ def ingest_nifc() -> dict:
     detections_labeled = label_fire_detections(con, polygons, fetched_at)
 
     try:
-        result = con.execute(
-            "SELECT COUNT(*) FROM fire_labels WHERE label = 1"
-        ).fetchone()
+        result = con.execute("SELECT COUNT(*) FROM fire_labels WHERE label = 1").fetchone()
         positive_labels = result[0] or 0
     except duckdb.CatalogException:
         positive_labels = 0

--- a/backend/tests/test_ndvi.py
+++ b/backend/tests/test_ndvi.py
@@ -1,6 +1,5 @@
 """
 test_ndvi.py — pytest tests for the Open-Meteo environmental conditions ingestor
-backend/tests/test_ndvi.py
 
 Test methodology: unit tests with mocked HTTP calls and a self-contained
 DuckDB fixture. No live Open-Meteo API calls are made.

--- a/backend/tests/test_ndvi.py
+++ b/backend/tests/test_ndvi.py
@@ -1,0 +1,277 @@
+"""
+test_ndvi.py — pytest tests for the Open-Meteo environmental conditions ingestor
+backend/tests/test_ndvi.py
+
+Test methodology: unit tests with mocked HTTP calls and a self-contained
+DuckDB fixture. No live Open-Meteo API calls are made.
+
+Coverage (TC-07 to TC-14):
+    TC-07  fetch_environmental_conditions: success path, all three values returned
+    TC-08  fetch_environmental_conditions: API failure returns None gracefully
+    TC-09  fetch_environmental_conditions: null values default to 0.0
+    TC-10  ingest_environmental: happy path inserts rows for all fire points
+    TC-11  ingest_environmental: dedup skips already-fetched points
+    TC-12  ingest_environmental: missing fires table returns 0
+    TC-13  ingest_environmental: missing DB raises FileNotFoundError
+    TC-14  ingest_environmental: API failure for all points returns 0
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from ai_wildfire_tracker.ingest.ndvi import (
+    _already_fetched_today,
+    ensure_environmental_table,
+    fetch_environmental_conditions,
+    ingest_environmental,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mem_db(tmp_path):
+    """Temp DuckDB with seeded fires table — two US fire detection points."""
+    db_file = str(tmp_path / "test_wildfire.db")
+    con = duckdb.connect(db_file)
+    con.execute(
+        """
+        CREATE TABLE fires (
+            latitude DOUBLE, longitude DOUBLE,
+            bright_ti4 DOUBLE, bright_ti5 DOUBLE,
+            frp DOUBLE, acq_date VARCHAR, acq_time VARCHAR, confidence VARCHAR
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO fires VALUES
+            (37.77, -122.42, 320.0, 310.0, 15.0, '2026-04-18', '1200', 'h'),
+            (34.05, -118.25, 305.0, 298.0,  8.0, '2026-04-18', '0900', 'n')
+        """
+    )
+    con.close()
+    return db_file
+
+
+# ---------------------------------------------------------------------------
+# Shared mock API response — matches real Open-Meteo structure (verified Postman)
+# ---------------------------------------------------------------------------
+
+OPEN_METEO_RESPONSE = {
+    "hourly": {
+        "time": ["2026-04-18T00:00", "2026-04-18T01:00"],
+        "soil_moisture_0_to_1cm": [0.12, 0.14],
+    },
+    "daily": {
+        "time": ["2026-04-18"],
+        "vapor_pressure_deficit_max": [1.95],
+        "et0_fao_evapotranspiration": [4.48],
+    },
+}
+
+
+def _make_mock_response(data: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = data
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: fetch_environmental_conditions (TC-07 to TC-09)
+# ---------------------------------------------------------------------------
+
+class TestFetchEnvironmentalConditions:
+    def test_tc07_returns_correct_values_on_success(self):
+        """TC-07: All three values returned and correctly parsed."""
+        with patch(
+            "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+            return_value=_make_mock_response(OPEN_METEO_RESPONSE),
+        ):
+            result = fetch_environmental_conditions(37.77, -122.42)
+
+        assert result is not None
+        # soil_moisture = mean([0.12, 0.14]) = 0.13
+        assert abs(result["soil_moisture"] - 0.13) < 0.001
+        assert abs(result["vpd_kpa"] - 1.95) < 0.001
+        assert abs(result["et0_mm"] - 4.48) < 0.001
+
+    def test_tc08_returns_none_on_request_failure(self):
+        """TC-08: Network error returns None, no crash."""
+        import requests
+
+        with patch(
+            "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+            side_effect=requests.RequestException("timeout"),
+        ):
+            result = fetch_environmental_conditions(37.77, -122.42)
+
+        assert result is None
+
+    def test_tc09_null_values_default_to_zero(self):
+        """TC-09: None values in response default to 0.0."""
+        response = {
+            "hourly": {
+                "time": ["2026-04-18T00:00"],
+                "soil_moisture_0_to_1cm": [None],
+            },
+            "daily": {
+                "time": ["2026-04-18"],
+                "vapor_pressure_deficit_max": [None],
+                "et0_fao_evapotranspiration": [None],
+            },
+        }
+        with patch(
+            "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+            return_value=_make_mock_response(response),
+        ):
+            result = fetch_environmental_conditions(37.77, -122.42)
+
+        assert result is not None
+        assert result["soil_moisture"] == 0.0
+        assert result["vpd_kpa"] == 0.0
+        assert result["et0_mm"] == 0.0
+
+    def test_returns_none_on_missing_keys(self):
+        """Malformed response missing expected keys returns None."""
+        with patch(
+            "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+            return_value=_make_mock_response({"unexpected": {}}),
+        ):
+            result = fetch_environmental_conditions(37.77, -122.42)
+
+        assert result is None
+
+    def test_soil_moisture_is_mean_of_hourly_values(self):
+        """Soil moisture is averaged across all hourly values."""
+        response = {
+            "hourly": {
+                "time": ["2026-04-18T00:00", "2026-04-18T01:00", "2026-04-18T02:00"],
+                "soil_moisture_0_to_1cm": [0.10, 0.20, 0.30],
+            },
+            "daily": {
+                "time": ["2026-04-18"],
+                "vapor_pressure_deficit_max": [1.0],
+                "et0_fao_evapotranspiration": [2.0],
+            },
+        }
+        with patch(
+            "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+            return_value=_make_mock_response(response),
+        ):
+            result = fetch_environmental_conditions(37.77, -122.42)
+
+        assert result is not None
+        assert abs(result["soil_moisture"] - 0.20) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: dedup helper
+# ---------------------------------------------------------------------------
+
+class TestAlreadyFetchedToday:
+    def test_returns_false_when_table_empty(self, mem_db):
+        con = duckdb.connect(mem_db)
+        ensure_environmental_table(con)
+        result = _already_fetched_today(con, 37.77, -122.42, "2026-04-18")
+        con.close()
+        assert result is False
+
+    def test_returns_true_when_row_exists(self, mem_db):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        con = duckdb.connect(mem_db)
+        ensure_environmental_table(con)
+        con.execute(
+            "INSERT INTO environmental_conditions VALUES (37.77, -122.42, ?, 0.1, 1.5, 3.0, ?)",
+            [today, today],
+        )
+        result = _already_fetched_today(con, 37.77, -122.42, today)
+        con.close()
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: ingest_environmental (TC-10 to TC-14)
+# ---------------------------------------------------------------------------
+
+class TestIngestEnvironmental:
+    def test_tc10_inserts_rows_for_all_fire_points(self, mem_db):
+        """TC-10: Happy path — 2 fire points in DB → 2 rows inserted."""
+        with (
+            patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", mem_db),
+            patch(
+                "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+                return_value=_make_mock_response(OPEN_METEO_RESPONSE),
+            ),
+            patch("ai_wildfire_tracker.ingest.ndvi.time.sleep"),
+        ):
+            inserted = ingest_environmental(limit=10)
+
+        assert inserted == 2
+
+        con = duckdb.connect(mem_db)
+        rows = con.execute("SELECT * FROM environmental_conditions").fetchall()
+        con.close()
+        assert len(rows) == 2
+
+    def test_tc11_skips_already_fetched_point(self, mem_db):
+        """TC-11: Point already fetched today is skipped, only new point inserted."""
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        con = duckdb.connect(mem_db)
+        ensure_environmental_table(con)
+        con.execute(
+            "INSERT INTO environmental_conditions VALUES (37.77, -122.42, ?, 0.1, 1.5, 3.0, ?)",
+            [today, today],
+        )
+        con.close()
+
+        with (
+            patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", mem_db),
+            patch(
+                "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+                return_value=_make_mock_response(OPEN_METEO_RESPONSE),
+            ),
+            patch("ai_wildfire_tracker.ingest.ndvi.time.sleep"),
+        ):
+            inserted = ingest_environmental(limit=10)
+
+        assert inserted == 1
+
+    def test_tc12_no_fires_table_returns_zero(self, tmp_path):
+        """TC-12: No fires table in DB returns 0 without crashing."""
+        empty_db = str(tmp_path / "empty.db")
+        duckdb.connect(empty_db).close()
+
+        with patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", empty_db):
+            inserted = ingest_environmental(limit=10)
+
+        assert inserted == 0
+
+    def test_tc13_missing_db_raises(self, tmp_path):
+        """TC-13: Missing DB file raises FileNotFoundError."""
+        missing = str(tmp_path / "nonexistent.db")
+
+        with patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", missing), pytest.raises(FileNotFoundError):
+            ingest_environmental()
+
+    def test_tc14_api_failure_skips_all_points(self, mem_db):
+        """TC-14: API failure for every point results in 0 rows inserted."""
+        import requests
+
+        with (
+            patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", mem_db),
+            patch(
+                "ai_wildfire_tracker.ingest.ndvi.SESSION.get",
+                side_effect=requests.RequestException("timeout"),
+            ),
+            patch("ai_wildfire_tracker.ingest.ndvi.time.sleep"),
+        ):
+            inserted = ingest_environmental(limit=10)
+
+        assert inserted == 0

--- a/backend/tests/test_ndvi.py
+++ b/backend/tests/test_ndvi.py
@@ -29,10 +29,10 @@ from ai_wildfire_tracker.ingest.ndvi import (
     ingest_environmental,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture()
 def mem_db(tmp_path):
@@ -86,6 +86,7 @@ def _make_mock_response(data: dict) -> MagicMock:
 # ---------------------------------------------------------------------------
 # Unit tests: fetch_environmental_conditions (TC-07 to TC-09)
 # ---------------------------------------------------------------------------
+
 
 class TestFetchEnvironmentalConditions:
     def test_tc07_returns_correct_values_on_success(self):
@@ -175,6 +176,7 @@ class TestFetchEnvironmentalConditions:
 # Unit tests: dedup helper
 # ---------------------------------------------------------------------------
 
+
 class TestAlreadyFetchedToday:
     def test_returns_false_when_table_empty(self, mem_db):
         con = duckdb.connect(mem_db)
@@ -199,6 +201,7 @@ class TestAlreadyFetchedToday:
 # ---------------------------------------------------------------------------
 # Integration tests: ingest_environmental (TC-10 to TC-14)
 # ---------------------------------------------------------------------------
+
 
 class TestIngestEnvironmental:
     def test_tc10_inserts_rows_for_all_fire_points(self, mem_db):
@@ -257,7 +260,10 @@ class TestIngestEnvironmental:
         """TC-13: Missing DB file raises FileNotFoundError."""
         missing = str(tmp_path / "nonexistent.db")
 
-        with patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", missing), pytest.raises(FileNotFoundError):
+        with (
+            patch("ai_wildfire_tracker.ingest.ndvi.DB_PATH", missing),
+            pytest.raises(FileNotFoundError),
+        ):
             ingest_environmental()
 
     def test_tc14_api_failure_skips_all_points(self, mem_db):

--- a/backend/tests/test_nifc.py
+++ b/backend/tests/test_nifc.py
@@ -1,6 +1,5 @@
 """
 test_nifc.py — pytest tests for the NIFC fire perimeter ingestor
-backend/tests/test_nifc.py
 
 Test methodology: unit tests with mocked HTTP calls and a self-contained
 DuckDB fixture. No live NIFC API calls are made. Shapely used for spatial ops.
@@ -131,9 +130,7 @@ class TestFetchNifcPerimeters:
         """ArcGIS error JSON response returns empty list."""
         with patch(
             "ai_wildfire_tracker.ingest.nifc.SESSION.get",
-            return_value=_make_mock_response(
-                {"error": {"code": 400, "message": "bad request"}}
-            ),
+            return_value=_make_mock_response({"error": {"code": 400, "message": "bad request"}}),
         ):
             result = fetch_nifc_perimeters()
 
@@ -190,9 +187,7 @@ class TestLabelFireDetections:
         con = duckdb.connect(mem_db)
         ensure_labels_table(con)
         label_fire_detections(con, polygons, "2026-04-19T00:00:00")
-        rows = con.execute(
-            "SELECT label FROM fire_labels WHERE latitude = 37.77"
-        ).fetchall()
+        rows = con.execute("SELECT label FROM fire_labels WHERE latitude = 37.77").fetchall()
         con.close()
         assert len(rows) == 1
         assert rows[0][0] == 1
@@ -203,9 +198,7 @@ class TestLabelFireDetections:
         con = duckdb.connect(mem_db)
         ensure_labels_table(con)
         label_fire_detections(con, polygons, "2026-04-19T00:00:00")
-        rows = con.execute(
-            "SELECT label FROM fire_labels WHERE latitude = 34.05"
-        ).fetchall()
+        rows = con.execute("SELECT label FROM fire_labels WHERE latitude = 34.05").fetchall()
         con.close()
         assert len(rows) == 1
         assert rows[0][0] == 0
@@ -246,8 +239,9 @@ class TestIngestNifc:
     def test_tc23_missing_db_raises(self, tmp_path):
         """TC-23: Missing DB file raises FileNotFoundError."""
         missing = str(tmp_path / "nonexistent.db")
-        with patch("ai_wildfire_tracker.ingest.nifc.DB_PATH", missing), pytest.raises(
-            FileNotFoundError
+        with (
+            patch("ai_wildfire_tracker.ingest.nifc.DB_PATH", missing),
+            pytest.raises(FileNotFoundError),
         ):
             ingest_nifc()
 

--- a/backend/tests/test_nifc.py
+++ b/backend/tests/test_nifc.py
@@ -1,0 +1,266 @@
+"""
+test_nifc.py — pytest tests for the NIFC fire perimeter ingestor
+backend/tests/test_nifc.py
+
+Test methodology: unit tests with mocked HTTP calls and a self-contained
+DuckDB fixture. No live NIFC API calls are made. Shapely used for spatial ops.
+
+Coverage (TC-15 to TC-23):
+    TC-15  fetch_nifc_perimeters: success path returns feature list
+    TC-16  fetch_nifc_perimeters: API failure returns empty list
+    TC-17  point_in_any_perimeter: point inside polygon → True
+    TC-18  point_in_any_perimeter: point outside all polygons → False
+    TC-19  label_fire_detections: point inside perimeter gets label 1
+    TC-20  label_fire_detections: point outside perimeter gets label 0
+    TC-21  label_fire_detections: already-labeled points are skipped
+    TC-22  ingest_nifc: happy path returns correct summary dict
+    TC-23  ingest_nifc: missing DB raises FileNotFoundError
+"""
+
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from ai_wildfire_tracker.ingest.nifc import (
+    build_shapely_polygons,
+    ensure_labels_table,
+    ensure_perimeter_table,
+    fetch_nifc_perimeters,
+    ingest_nifc,
+    label_fire_detections,
+    point_in_any_perimeter,
+    store_perimeters,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mem_db(tmp_path):
+    """Temp DuckDB with seeded fires — SF point (inside test polygon) and LA point (outside)."""
+    db_file = str(tmp_path / "test_wildfire.db")
+    con = duckdb.connect(db_file)
+    con.execute(
+        """
+        CREATE TABLE fires (
+            latitude DOUBLE, longitude DOUBLE,
+            bright_ti4 DOUBLE, bright_ti5 DOUBLE,
+            frp DOUBLE, acq_date VARCHAR, acq_time VARCHAR, confidence VARCHAR
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO fires VALUES
+            (37.77, -122.42, 320.0, 310.0, 15.0, '2026-04-19', '1200', 'h'),
+            (34.05, -118.25, 305.0, 298.0,  8.0, '2026-04-19', '0900', 'n')
+        """
+    )
+    con.close()
+    return db_file
+
+
+# ---------------------------------------------------------------------------
+# GeoJSON test fixture — small square covering SF area only
+# ---------------------------------------------------------------------------
+
+SF_POLYGON_FEATURE = {
+    "type": "Feature",
+    "properties": {
+        "poly_IncidentName": "TEST FIRE",
+        "poly_GISAcres": 500.0,
+        "poly_CreateDate": "2026-04-19",
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-123.0, 37.5],
+                [-122.0, 37.5],
+                [-122.0, 38.0],
+                [-123.0, 38.0],
+                [-123.0, 37.5],
+            ]
+        ],
+    },
+}
+
+
+def _make_mock_response(data: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = data
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: fetch_nifc_perimeters (TC-15, TC-16)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNifcPerimeters:
+    def test_tc15_returns_feature_list_on_success(self):
+        """TC-15: Successful API call returns list of GeoJSON features."""
+        with patch(
+            "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+            return_value=_make_mock_response({"features": [SF_POLYGON_FEATURE]}),
+        ):
+            result = fetch_nifc_perimeters()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["properties"]["poly_IncidentName"] == "TEST FIRE"
+
+    def test_tc16_returns_empty_list_on_api_failure(self):
+        """TC-16: Network error returns empty list, no crash."""
+        import requests
+
+        with patch(
+            "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+            side_effect=requests.RequestException("timeout"),
+        ):
+            result = fetch_nifc_perimeters()
+
+        assert result == []
+
+    def test_returns_empty_list_on_api_error_response(self):
+        """ArcGIS error JSON response returns empty list."""
+        with patch(
+            "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+            return_value=_make_mock_response(
+                {"error": {"code": 400, "message": "bad request"}}
+            ),
+        ):
+            result = fetch_nifc_perimeters()
+
+        assert result == []
+
+    def test_returns_empty_list_on_missing_features_key(self):
+        """Malformed response missing 'features' key returns empty list."""
+        with patch(
+            "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+            return_value=_make_mock_response({}),
+        ):
+            result = fetch_nifc_perimeters()
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: spatial helpers (TC-17, TC-18)
+# ---------------------------------------------------------------------------
+
+
+class TestSpatialHelpers:
+    def setup_method(self):
+        self.polygons = build_shapely_polygons([SF_POLYGON_FEATURE])
+
+    def test_tc17_point_inside_polygon_returns_true(self):
+        """TC-17: SF point (37.77, -122.42) inside test polygon → True."""
+        assert point_in_any_perimeter(37.77, -122.42, self.polygons) is True
+
+    def test_tc18_point_outside_all_polygons_returns_false(self):
+        """TC-18: LA point (34.05, -118.25) outside test polygon → False."""
+        assert point_in_any_perimeter(34.05, -118.25, self.polygons) is False
+
+    def test_empty_polygon_list_always_returns_false(self):
+        """No polygons loaded → always returns False."""
+        assert point_in_any_perimeter(37.77, -122.42, []) is False
+
+    def test_build_shapely_polygons_returns_valid_geometries(self):
+        """Valid GeoJSON feature produces exactly one Shapely polygon."""
+        polygons = build_shapely_polygons([SF_POLYGON_FEATURE])
+        assert len(polygons) == 1
+        assert polygons[0].is_valid
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: label_fire_detections (TC-19, TC-20, TC-21)
+# ---------------------------------------------------------------------------
+
+
+class TestLabelFireDetections:
+    def test_tc19_point_inside_perimeter_gets_label_1(self, mem_db):
+        """TC-19: SF detection inside polygon → label = 1."""
+        polygons = build_shapely_polygons([SF_POLYGON_FEATURE])
+        con = duckdb.connect(mem_db)
+        ensure_labels_table(con)
+        label_fire_detections(con, polygons, "2026-04-19T00:00:00")
+        rows = con.execute(
+            "SELECT label FROM fire_labels WHERE latitude = 37.77"
+        ).fetchall()
+        con.close()
+        assert len(rows) == 1
+        assert rows[0][0] == 1
+
+    def test_tc20_point_outside_perimeter_gets_label_0(self, mem_db):
+        """TC-20: LA detection outside polygon → label = 0."""
+        polygons = build_shapely_polygons([SF_POLYGON_FEATURE])
+        con = duckdb.connect(mem_db)
+        ensure_labels_table(con)
+        label_fire_detections(con, polygons, "2026-04-19T00:00:00")
+        rows = con.execute(
+            "SELECT label FROM fire_labels WHERE latitude = 34.05"
+        ).fetchall()
+        con.close()
+        assert len(rows) == 1
+        assert rows[0][0] == 0
+
+    def test_tc21_skips_already_labeled_points(self, mem_db):
+        """TC-21: Second call with same detections inserts 0 new rows."""
+        polygons = build_shapely_polygons([SF_POLYGON_FEATURE])
+        con = duckdb.connect(mem_db)
+        ensure_labels_table(con)
+        count1 = label_fire_detections(con, polygons, "2026-04-19T00:00:00")
+        count2 = label_fire_detections(con, polygons, "2026-04-19T01:00:00")
+        con.close()
+        assert count1 == 2
+        assert count2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: ingest_nifc (TC-22, TC-23)
+# ---------------------------------------------------------------------------
+
+
+class TestIngestNifc:
+    def test_tc22_happy_path_returns_correct_summary(self, mem_db):
+        """TC-22: Full ingest returns summary with correct counts."""
+        with (
+            patch("ai_wildfire_tracker.ingest.nifc.DB_PATH", mem_db),
+            patch(
+                "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+                return_value=_make_mock_response({"features": [SF_POLYGON_FEATURE]}),
+            ),
+        ):
+            summary = ingest_nifc()
+
+        assert summary["perimeters_inserted"] == 1
+        assert summary["detections_labeled"] == 2
+        assert summary["positive_labels"] == 1
+
+    def test_tc23_missing_db_raises(self, tmp_path):
+        """TC-23: Missing DB file raises FileNotFoundError."""
+        missing = str(tmp_path / "nonexistent.db")
+        with patch("ai_wildfire_tracker.ingest.nifc.DB_PATH", missing), pytest.raises(
+            FileNotFoundError
+        ):
+            ingest_nifc()
+
+    def test_empty_perimeters_labels_all_zero(self, mem_db):
+        """Empty NIFC response → all detections labeled 0, no crash."""
+        with (
+            patch("ai_wildfire_tracker.ingest.nifc.DB_PATH", mem_db),
+            patch(
+                "ai_wildfire_tracker.ingest.nifc.SESSION.get",
+                return_value=_make_mock_response({"features": []}),
+            ),
+        ):
+            summary = ingest_nifc()
+
+        assert summary["perimeters_inserted"] == 0
+        assert summary["positive_labels"] == 0


### PR DESCRIPTION
Downloads WFIGS current interagency fire perimeters from the NIFC ArcGIS
REST API and performs a spatial join against FIRMS fire detection points
to assign binary training labels for the Random Forest model.

Label definition:
    1 = a NIFC fire perimeter overlaps this detection point (fire confirmed)
    0 = no perimeter overlap (no confirmed fire at this point)

NIFC ArcGIS REST endpoint (no API key required, public domain):
    https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/
    WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query

Verified working Postman call :
    GET .../query?where=1%3D1&outFields=poly_IncidentName,poly_GISAcres,
    poly_CreateDate&returnGeometry=true&outSR=4326&f=geojson&resultRecordCount=5

Tables created:
    fire_perimeters — raw perimeter polygons (GeoJSON geometry as string)
    fire_labels     — one row per FIRMS detection with label 0 or 1