### PR TITLE
Add frontend E2E workflow and stale data validation

### DIFF
--- a/frontend/e2e/fires.spec.ts
+++ b/frontend/e2e/fires.spec.ts
@@ -64,4 +64,30 @@ test.describe("AI Wildfire Tracker E2E", () => {
     await expect(page.getByTestId("events-count")).toHaveText("2 events");
     await expect(page.getByTestId("event-row")).toHaveCount(2);
   });
+
+  test("shows stale-data banner when fire records are old", async ({ page }) => {
+  await page.route("**/fires*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          lat: 34.05,
+          lon: -118.25,
+          brightness: 360,
+          frp: 55,
+          confidence: "high",
+          acq_date: "2020-01-01",
+          acq_time: "1210",
+          risk: 238,
+        },
+      ]),
+    });
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByTestId("stale-data-banner")).toBeVisible();
+  await expect(page.getByTestId("stale-data-banner")).toContainText(/stale/i);
+});
 });

--- a/frontend/e2e/fires.spec.ts
+++ b/frontend/e2e/fires.spec.ts
@@ -2,10 +2,13 @@ import { expect, test } from "@playwright/test";
 
 test.describe("AI Wildfire Tracker E2E", () => {
   test("loads with seeded California results and no API error", async ({ page }) => {
-    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.goto("/", { waitUntil: "networkidle" });
 
-    await expect(page.getByTestId("events-count")).toHaveText("3 events");
-    await expect(page.locator(".error-banner")).toHaveCount(0);
+  await expect(page.getByText("Loading...")).toHaveCount(0);
+  await expect(page.getByTestId("events-count")).toHaveText("3 events", {
+    timeout: 10000,
+  });
+  await expect(page.locator(".error-banner")).toHaveCount(0);
   });
 
   test("starts with California-only filter enabled", async ({ page }) => {

--- a/frontend/e2e/performance.spec.ts
+++ b/frontend/e2e/performance.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+function makeFireEvents(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    lat: 32.6 + (index % 80) * 0.05,
+    lon: -124.0 + (index % 80) * 0.05,
+    brightness: 300 + (index % 100),
+    frp: 5 + (index % 75),
+    confidence: index % 2 === 0 ? "high" : "nominal",
+    acq_date: "2026-04-14",
+    acq_time: String(800 + (index % 900)).padStart(4, "0"),
+    risk: 150 + (index % 120),
+  }));
+}
+
+test.describe("Frontend performance", () => {
+  test("loads and filters a larger wildfire dataset within acceptable time", async ({ page }) => {
+    const largeDataset = makeFireEvents(1000);
+
+    await page.route("**/fires*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(largeDataset),
+      });
+    });
+
+    const startLoad = Date.now();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("events-count")).toBeVisible();
+    const loadMs = Date.now() - startLoad;
+
+    expect(loadMs).toBeLessThan(2500);
+
+    const startFilter = Date.now();
+    await page.getByTestId("confidence-filter").selectOption("high");
+    await expect(page.getByTestId("events-count")).toContainText("events");
+    const filterMs = Date.now() - startFilter;
+
+    expect(filterMs).toBeLessThan(2500);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,10 +11,10 @@ export default defineConfig({
   expect: {
     timeout: 5_000,
   },
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
-  workers: isCI ? 1 : undefined,
+  workers: 1,
   reporter: isCI ? [["github"], ["html", { open: "never" }]] : [["list"]],
   use: {
     baseURL: `http://127.0.0.1:${frontendPort}`,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -65,6 +65,25 @@ function buildFireId(fire, index) {
   ].join("|");
 }
 
+function isStaleFireData(events, staleDays = 2) {
+  if (!events || events.length === 0) return false;
+
+  const newestDate = events
+    .map((event) => {
+      const time = String(event.acq_time ?? "0000").padStart(4, "0");
+      return new Date(`${event.acq_date}T${time.slice(0, 2)}:${time.slice(2, 4)}:00`);
+    })
+    .filter((date) => !Number.isNaN(date.getTime()))
+    .sort((a, b) => b - a)[0];
+
+  if (!newestDate) return false;
+
+  const ageMs = Date.now() - newestDate.getTime();
+  const staleMs = staleDays * 24 * 60 * 60 * 1000;
+
+  return ageMs > staleMs;
+}
+
 function FitBounds({ fires }) {
   const map = useMap();
 
@@ -154,6 +173,8 @@ export default function App() {
     [fires]
   );
 
+  const showStaleBanner = isStaleFireData(preparedFires);
+
   const filteredFires = useMemo(
     () =>
       preparedFires.filter((f) => {
@@ -234,6 +255,12 @@ export default function App() {
         </div>
 
       </header>
+
+      {showStaleBanner && !loading && !err && (
+        <div className="stale-data-banner" data-testid="stale-data-banner">
+          Wildfire data may be stale. Latest fire record is older than 2 days.
+        </div>
+      )}
 
       <div className="main-layout">
         <section className="controls-panel">


### PR DESCRIPTION
This PR adds frontend E2E workflow and stale-data validation for Sprint 3 testing.

Changes included:

Added/updated Playwright E2E tests for the dashboard workflow
Verified seeded backend data loads into the frontend
Tested California-only filtering, expanding to full U.S. results, confidence filtering, FRP sorting, and empty-state behavior
Added stale-data banner validation for old wildfire records
Added event count consistency checks after filters are applied
Added frontend performance test for loading/filtering a larger mocked wildfire dataset
Updated Playwright configuration so E2E tests run reliably with a seeded backend and frontend server

Validation:

Ran npm run test:e2e
Result: 9 Playwright tests passed

This supports the Sprint 3 test plan by covering:

End-to-end workflow testing
Failure/recovery behavior
Frontend responsiveness/performance
User-facing stale-data warning behavior
Cross-layer consistency between backend data and frontend display