### PR TITLE
fix(data-loader): read configs.DB_PATH at call time for test isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── NASA FIRMS API ──────────────────────────────────────────────────────────
 # Get a free key at: https://firms.modaps.eosdis.nasa.gov/api/area/
-FIRMS_API_KEY=your_api_key_here
+FIRMS_API_KEY=
 
 # ── NOAA HMS Ingestion ──────────────────────────────────────────────────────
 # CSV endpoint that includes at least latitude/longitude and date/time fields.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,10 +382,11 @@ jobs:
           echo "Pushed ${IMAGE}:${BUILD_SHORT}" >> $GITHUB_STEP_SUMMARY
 
       - name: Trigger Render deploy
-        if: ${{ secrets.RENDER_DEPLOY_HOOK != '' }}
         run: |
-          curl -s "${{ secrets.RENDER_DEPLOY_HOOK }}" | jq .
-          echo "Render deploy triggered" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ secrets.RENDER_DEPLOY_HOOK }}" ]; then
+            curl -s "${{ secrets.RENDER_DEPLOY_HOOK }}" | jq .
+            echo "Render deploy triggered" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Write deploy summary
         run: |

--- a/ai/src/ai_wildfire/data_loader.py
+++ b/ai/src/ai_wildfire/data_loader.py
@@ -1,11 +1,11 @@
 import duckdb
 
-from .configs import DB_PATH
+from . import configs
 
 
 def load_firms_table(limit=None):
     """Load the `fires` table from wildfire.db produced by backend ingestion."""
-    con = duckdb.connect(DB_PATH)
+    con = duckdb.connect(configs.DB_PATH)
     q = "SELECT * FROM fires"
     if limit:
         q += f" LIMIT {int(limit)}"

--- a/ai/src/ai_wildfire/tests/conftest.py
+++ b/ai/src/ai_wildfire/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
-from ai_wildfire import configs, data_loader, model_store
+from ai_wildfire import configs, model_store
 from ai_wildfire.features import build_feature_matrix
 from ai_wildfire.utils import set_seed
 

--- a/ai/src/ai_wildfire/tests/conftest.py
+++ b/ai/src/ai_wildfire/tests/conftest.py
@@ -44,7 +44,6 @@ def seeded_golden_db(tmp_path, monkeypatch, golden_df):
     con.execute("INSERT INTO fires SELECT * FROM golden_df")
     con.close()
     monkeypatch.setattr(configs, "DB_PATH", db_path)
-    monkeypatch.setattr(data_loader, "DB_PATH", db_path)
     return db_path
 
 

--- a/ai/src/ai_wildfire/tests/test_predict.py
+++ b/ai/src/ai_wildfire/tests/test_predict.py
@@ -50,7 +50,7 @@ def test_high_confidence_detections_score_above_threshold():
     con.close()
 
     try:
-        with patch("ai_wildfire.data_loader.DB_PATH", db_path):
+        with patch("ai_wildfire.configs.DB_PATH", db_path):
             result = predict_from_db(limit=10)
         high_conf = result[result["confidence"] == "h"]
         assert len(high_conf) > 0

--- a/backend/src/ai_wildfire_tracker/ingest/firms.py
+++ b/backend/src/ai_wildfire_tracker/ingest/firms.py
@@ -90,6 +90,8 @@ def ensure_fires_table(con: duckdb.DuckDBPyConnection) -> None:
 def _count_existing(con: duckdb.DuckDBPyConnection, date: str) -> int:
     try:
         result = con.execute("SELECT COUNT(*) FROM fires WHERE acq_date = ?", [date]).fetchone()
+        if result is None:
+            return 0
         return result[0] or 0
     except duckdb.CatalogException:
         return 0
@@ -161,7 +163,7 @@ def fetch_firms_window(
         source,
         start_date or "latest",
     )
-    return df
+    return pd.DataFrame(df)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/ai_wildfire_tracker/ingest/noaa_hms.py
+++ b/backend/src/ai_wildfire_tracker/ingest/noaa_hms.py
@@ -106,7 +106,7 @@ def _normalize_noaa_hms(df: pd.DataFrame) -> pd.DataFrame:
         {"NaT": datetime.now(timezone.utc).strftime("%Y-%m-%d")}
     )
     normalized["acq_time"] = normalized["acq_time"].replace({"nan": "0000", "None": "0000"})
-    return normalized
+    return pd.DataFrame(normalized)
 
 
 def ingest_noaa_hms() -> None:


### PR DESCRIPTION
test_load_firms_table_missing_db_raises reliably use the patched path regardless of whether wildfire.db exists locally.